### PR TITLE
Client: `tokens` rpc call

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -183,13 +183,13 @@ impl SafeClient {
     #[tracing::instrument(skip(self, filters))]
     pub async fn filtered_tokens(
         &self,
-        filters: impl AsRef<HashMap<&'static str, String>>,
+        filters: impl IntoIterator<Item = (&'static str, String)>,
     ) -> ClientResult<TokenInfoResponse> {
         json_get!(
             &self.client,
             TokenInfoRequest::url(self.url()),
             TokenInfoResponse,
-            filters.as_ref()
+            filters,
         )
         .map(Option::unwrap)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,6 +15,7 @@ use crate::{
         info::{SafeInfoRequest, SafeInfoResponse},
         msig_history::{MsigHistoryFilters, MsigHistoryResponse, MsigTxRequest, MsigTxResponse},
         propose::{MetaTransactionData, ProposeRequest, SafeTransactionData},
+        tokens::{TokenInfoFilters, TokenInfoRequest, TokenInfoResponse},
     },
 };
 
@@ -165,6 +166,38 @@ impl SafeClient {
             SafeInfoResponse,
         )
         .map(Option::unwrap)
+    }
+
+    /// Get information about tokens available on the API
+    #[tracing::instrument(skip(self))]
+    pub async fn tokens(&self) -> ClientResult<TokenInfoResponse> {
+        json_get!(
+            &self.client,
+            TokenInfoRequest::url(self.url()),
+            TokenInfoResponse,
+        )
+        .map(Option::unwrap)
+    }
+
+    /// Get fitered information about tokens available on the API
+    #[tracing::instrument(skip(self, filters))]
+    pub async fn filtered_tokens(
+        &self,
+        filters: impl AsRef<HashMap<&'static str, String>>,
+    ) -> ClientResult<TokenInfoResponse> {
+        json_get!(
+            &self.client,
+            TokenInfoRequest::url(self.url()),
+            TokenInfoResponse,
+            filters.as_ref()
+        )
+        .map(Option::unwrap)
+    }
+
+    /// Create a filter builder for tokens
+    #[tracing::instrument(skip(self))]
+    pub fn tokens_builder(&self) -> TokenInfoFilters<'_> {
+        TokenInfoFilters::new(self)
     }
 
     /// Get the history of Msig transactions from the API

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,8 +47,7 @@ macro_rules! json_get {
     };
     ($client:expr, $url:expr, $expected:ty, $query:expr) => {{
         let mut url = $url.clone();
-        let pairs = $query.iter();
-        url.query_pairs_mut().extend_pairs(pairs);
+        url.query_pairs_mut().extend_pairs($query);
         tracing::debug!(url = url.as_str(), "Dispatching api request");
         let resp = $client.get($url).send().await?;
         let status = resp.status();

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -4,6 +4,9 @@ pub mod common;
 /// General Safe Info
 pub mod info;
 
+/// Token Info
+pub mod tokens;
+
 /// History of Safe msig transactions
 pub mod msig_history;
 

--- a/src/rpc/tokens.rs
+++ b/src/rpc/tokens.rs
@@ -185,27 +185,3 @@ pub struct TokenIfResponse {
 
 /// Response for Token Info requests
 pub type TokenInfoResponse = Paginated<TokenIfResponse>;
-
-#[cfg(test)]
-mod test {
-
-    use super::TokenIfResponse;
-
-    #[test]
-    fn it_parses() {
-        #[derive(serde::Deserialize)]
-        struct Shape {
-            results: Vec<serde_json::Value>,
-        }
-
-        let f = std::fs::read_to_string("/Users/eop/dev/nomad/safe-sdk/tmp.json").unwrap();
-
-        let s: Shape = serde_json::from_str(&f).unwrap();
-        for (i, result) in s.results.into_iter().enumerate() {
-            if let Err(e) = serde_json::from_value::<TokenIfResponse>(result) {
-                dbg!(e);
-                dbg!(i);
-            }
-        }
-    }
-}

--- a/src/rpc/tokens.rs
+++ b/src/rpc/tokens.rs
@@ -164,7 +164,7 @@ impl From<String> for TokenType {
 /// token info response
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct TokenIfResponse {
+pub struct TokenResponse {
     /// The token type (ERC20, ERC721, etc)
     #[serde(rename(deserialize = "type"))]
     // #[serde(skip)]
@@ -184,4 +184,4 @@ pub struct TokenIfResponse {
 }
 
 /// Response for Token Info requests
-pub type TokenInfoResponse = Paginated<TokenIfResponse>;
+pub type TokenInfoResponse = Paginated<TokenResponse>;

--- a/src/rpc/tokens.rs
+++ b/src/rpc/tokens.rs
@@ -30,18 +30,12 @@ pub struct TokenInfoFilters<'a> {
     pub(crate) client: &'a SafeClient,
 }
 
-impl<'a> AsRef<HashMap<&'static str, String>> for TokenInfoFilters<'a> {
-    fn as_ref(&self) -> &HashMap<&'static str, String> {
-        &self.filters
-    }
-}
-
 impl<'a> TokenInfoFilters<'a> {
     const DECIMAL_KEYS: &'static [&'static str] = &["decimals__lt", "decimals__gt", "decimals"];
 
     /// Dispatch the request to the API, querying tokens from the API
     pub async fn query(self) -> ClientResult<TokenInfoResponse> {
-        self.client.filtered_tokens(&self).await
+        self.client.filtered_tokens(self.filters).await
     }
 
     /// Insert a KV pair into the internal mapping for later URL encoding
@@ -139,28 +133,6 @@ impl<'a> TokenInfoFilters<'a> {
     }
 }
 
-/// The type of the token (ERC20, ERC721, etc)
-#[derive(Debug, Eq, PartialEq, Clone, serde::Deserialize)]
-pub enum TokenType {
-    /// ERC20 type
-    ERC20,
-    /// ERC721 type
-    ERC721,
-    /// ERC1155 type
-    ERC1155,
-}
-
-impl From<String> for TokenType {
-    fn from(s: String) -> Self {
-        match s.as_str() {
-            "ERC20" => TokenType::ERC20,
-            "ERC721" => TokenType::ERC721,
-            "ERC1155" => TokenType::ERC1155,
-            _ => panic!("Unknown token type"),
-        }
-    }
-}
-
 /// token info response
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -168,7 +140,7 @@ pub struct TokenResponse {
     /// The token type (ERC20, ERC721, etc)
     #[serde(rename(deserialize = "type"))]
     // #[serde(skip)]
-    pub token_type: TokenType,
+    pub token_type: String,
     /// The address of the token
     pub address: String,
     /// The name of the token

--- a/src/rpc/tokens.rs
+++ b/src/rpc/tokens.rs
@@ -133,7 +133,7 @@ impl<'a> TokenInfoFilters<'a> {
     }
 }
 
-/// token info response
+/// Token info response
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenResponse {
@@ -150,8 +150,6 @@ pub struct TokenResponse {
     /// The number of decimals of the token
     pub decimals: Option<u32>,
     /// The Logo URI of the token, if it exists
-    #[serde(rename(deserialize = "logoUri"))]
-    // #[serde(skip)]
     pub logo_uri: String,
 }
 

--- a/src/rpc/tokens.rs
+++ b/src/rpc/tokens.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+
+use ethers::types::Address;
+use reqwest::Url;
+use serde::Serialize;
+
+use crate::{client::ClientResult, SafeClient};
+
+use super::common::Paginated;
+
+/// token info request
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TokenInfoRequest;
+
+impl TokenInfoRequest {
+    /// Return the URL to which to dispatch this request
+    pub fn url(root: &Url) -> Url {
+        let mut url = root.clone();
+        url.set_path("api/v1/tokens/");
+        url
+    }
+}
+
+/// Token info Request with filters
+#[derive(Clone, Serialize)]
+pub struct TokenInfoFilters<'a> {
+    #[serde(flatten)]
+    pub(crate) filters: HashMap<&'static str, String>,
+    #[serde(skip)]
+    pub(crate) client: &'a SafeClient,
+}
+
+impl<'a> AsRef<HashMap<&'static str, String>> for TokenInfoFilters<'a> {
+    fn as_ref(&self) -> &HashMap<&'static str, String> {
+        &self.filters
+    }
+}
+
+impl<'a> TokenInfoFilters<'a> {
+    const DECIMAL_KEYS: &'static [&'static str] = &["decimals__lt", "decimals__gt", "decimals"];
+
+    /// Dispatch the request to the API, querying tokens from the API
+    pub async fn query(self) -> ClientResult<TokenInfoResponse> {
+        self.client.filtered_tokens(&self).await
+    }
+
+    /// Insert a KV pair into the internal mapping for later URL encoding
+    ///
+    /// Somewhat more expensive and brittle than required, as it uses
+    /// serde_json. Using display would cause hashes and addresses to be
+    /// abbreviated `0xabcd....1234`
+    fn insert<S: Serialize>(&mut self, k: &'static str, v: S) {
+        self.filters.insert(k, serde_json::to_string(&v).unwrap());
+    }
+
+    /// Return the URL to which to dispatch this request
+    pub fn url(root: &Url) -> Url {
+        let mut url = root.clone();
+        url.set_path("api/v1/tokens/");
+        url
+    }
+
+    /// Instantiate from a client
+    pub(crate) fn new(client: &'a SafeClient) -> Self {
+        Self {
+            filters: Default::default(),
+            client,
+        }
+    }
+
+    fn clear_decimals(&mut self) {
+        for k in Self::DECIMAL_KEYS {
+            self.filters.remove(k);
+        }
+    }
+
+    /// Filters tokens by name
+    pub fn name(mut self, name: String) -> Self {
+        self.filters.insert("name", name);
+        self
+    }
+
+    /// Filter tokens by address
+    pub fn address(mut self, address: Address) -> Self {
+        self.insert("address", address);
+        self
+    }
+
+    /// Filter tokens by symbol
+    pub fn symbol(mut self, symbol: String) -> Self {
+        self.filters.insert("symbol", symbol);
+        self
+    }
+
+    /// Filter tokens with `decimals >= min_decimals`
+    /// Clears any exact decimals filter
+    pub fn min_decimals(mut self, decimals: u64) -> Self {
+        self.filters.remove("decimals");
+        self.insert("decimals__gt", decimals.saturating_sub(1));
+        self
+    }
+
+    /// Filter tokens with `decimals <= max_decimals`
+    /// Clears any exact decimals filter
+    pub fn max_decimals(mut self, decimals: u64) -> Self {
+        self.filters.remove("decimals");
+        self.insert("decimals__lt", decimals.saturating_add(1));
+        self
+    }
+
+    /// Filter tokens by exact decimals
+    /// Clears any min or max decimals filters
+    pub fn decimals(mut self, decimals: u64) -> Self {
+        self.clear_decimals();
+        self.insert("decimals", decimals);
+        self
+    }
+
+    /// Specify page limit. If more results than limit are returned, results in
+    /// a paginated response
+    pub fn limit(mut self, limit: u64) -> Self {
+        self.insert("limit", limit);
+        self
+    }
+
+    /// Specify offset in results. Used in pagination, not recommended to be
+    /// specified manually
+    pub fn offset(mut self, offset: u64) -> Self {
+        self.insert("offset", offset);
+        self
+    }
+
+    /// Converts to a URL with query string
+    pub fn to_url(self) -> Url {
+        let mut url = self.client.url().clone();
+        url = Self::url(&url);
+        url.query_pairs_mut().extend_pairs(self.filters.iter());
+        url
+    }
+}
+
+/// The type of the token (ERC20, ERC721, etc)
+#[derive(Debug, Eq, PartialEq, Clone, serde::Deserialize)]
+pub enum TokenType {
+    /// ERC20 type
+    ERC20,
+    /// ERC721 type
+    ERC721,
+    /// ERC1155 type
+    ERC1155,
+}
+
+impl From<String> for TokenType {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "ERC20" => TokenType::ERC20,
+            "ERC721" => TokenType::ERC721,
+            "ERC1155" => TokenType::ERC1155,
+            _ => panic!("Unknown token type"),
+        }
+    }
+}
+
+/// token info response
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenIfResponse {
+    /// The token type (ERC20, ERC721, etc)
+    #[serde(rename(deserialize = "type"))]
+    // #[serde(skip)]
+    pub token_type: TokenType,
+    /// The address of the token
+    pub address: String,
+    /// The name of the token
+    pub name: String,
+    /// The symbol of the token
+    pub symbol: String,
+    /// The number of decimals of the token
+    pub decimals: Option<u32>,
+    /// The Logo URI of the token, if it exists
+    #[serde(rename(deserialize = "logoUri"))]
+    // #[serde(skip)]
+    pub logo_uri: String,
+}
+
+/// Response for Token Info requests
+pub type TokenInfoResponse = Paginated<TokenIfResponse>;
+
+#[cfg(test)]
+mod test {
+
+    use super::TokenIfResponse;
+
+    #[test]
+    fn it_parses() {
+        #[derive(serde::Deserialize)]
+        struct Shape {
+            results: Vec<serde_json::Value>,
+        }
+
+        let f = std::fs::read_to_string("/Users/eop/dev/nomad/safe-sdk/tmp.json").unwrap();
+
+        let s: Shape = serde_json::from_str(&f).unwrap();
+        for (i, result) in s.results.into_iter().enumerate() {
+            if let Err(e) = serde_json::from_value::<TokenIfResponse>(result) {
+                dbg!(e);
+                dbg!(i);
+            }
+        }
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -46,6 +46,12 @@ async fn it_gets_history() {
 
 #[tokio::test]
 #[tracing_test::traced_test]
+async fn it_gets_tokens() {
+    dbg!(CLIENT.tokens().await.unwrap());
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
 async fn it_proposes() {
     let tx: MetaTransactionData = MetaTransactionData {
         to: ChecksumAddress::from(*ADDR),


### PR DESCRIPTION
Implements the `tokens` RPC call, which can be used to get information about tokens through the Safe API.

I think this was a good way to get acquainted with the codebase; the route is simple, so it looks a lot like the `msig_history` file. happy to accommodate any changes you wanna make to the API!